### PR TITLE
Show highlight colors in overview ruler

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Heatmap adds the following commands to the command palette:
 |---|---|---|---|
 |`heatmap.heatLevels`|The number of different heat levels to visualise.|Integer|10|
 |`heatmap.heatColour`|The R,G,B of the brightest heat level.|String|`200,0,0`|
+|`heatmap.showInRuler`|Whether to show the heatmap in the overview ruler.|Boolean|true|
 
 ## Thanks
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,11 @@
           "type": "string",
           "default": "200,0,0",
           "description": "The heat colour to use as R,G,B between 0-255 for each."
+        },
+        "heatmap.showInRuler": {
+          "type": "boolean",
+          "default": true,
+          "description": "When the heatmap is switched on, also show it in the overview ruler."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -160,6 +160,7 @@ function buildDecorations(){
 	heatStyles.length = 0;
 	for (let i = 0; i < heatLevels; ++i) {
 		heatStyles.push(vscode.window.createTextEditorDecorationType({
+			rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed,
 			backgroundColor: 'rgba(' + heatColour + ', ' + (heatPerLevel * i) + ')',
 		}));
 	}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -143,6 +143,7 @@ function buildDecorations(){
 	const config = vscode.workspace.getConfiguration('heatmap');
 	const heatLevels = config.get<number>('heatLevels') || DEFAULT_HEAT_LEVELS;
 	const heatColour = config.get<string>('heatColour') || DEFAULT_HEAT_COLOUR;
+	const showInRuler = config.get<boolean>('showInRuler');
 
 	if (heatLevels < 1) {
 		vscode.window.showErrorMessage('Heatmap: Invalid number of heat levels (must be >1).');
@@ -159,9 +160,11 @@ function buildDecorations(){
 
 	heatStyles.length = 0;
 	for (let i = 0; i < heatLevels; ++i) {
+		const colorString = 'rgba(' + heatColour + ', ' + (heatPerLevel * i) + ')';
 		heatStyles.push(vscode.window.createTextEditorDecorationType({
 			rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed,
-			backgroundColor: 'rgba(' + heatColour + ', ' + (heatPerLevel * i) + ')',
+			backgroundColor: colorString,
+			overviewRulerColor: showInRuler ? colorString : undefined,
 		}));
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,12 +50,13 @@ function getGitTimestampsForLines(document: vscode.TextDocument): undefined | nu
 	return timestamps;
 }
 
-function updateHeatmap(){
-	const editor = vscode.window.activeTextEditor;
-	if (!editor) {
-		return;
-	}
+function updateVisibleHeatmaps(){
+	vscode.window.visibleTextEditors.forEach(editor => {
+		updateHeatmapForEditor(editor);
+	});
+}
 
+function updateHeatmapForEditor(editor:vscode.TextEditor){
 	// clear whatever was already there
 	heatStyles.forEach(style => editor.setDecorations(style, []));
 
@@ -120,7 +121,7 @@ function setHeatmapEnabled(enable: boolean) {
 		enabledForFiles.delete(editor.document.uri);
 	}
 
-	updateHeatmap();
+	updateVisibleHeatmaps();
 }
 
 function toggleHeatmap(){
@@ -135,7 +136,7 @@ function toggleHeatmap(){
 		enabledForFiles.add(editor.document.uri);
 	}
 
-	updateHeatmap();
+	updateVisibleHeatmaps();
 }
 
 export function activate(context: vscode.ExtensionContext) {
@@ -164,8 +165,8 @@ export function activate(context: vscode.ExtensionContext) {
 
 	commands.forEach(cmd => context.subscriptions.push(cmd));
 
-	vscode.window.onDidChangeActiveTextEditor(_ => {
-        updateHeatmap();
+	vscode.window.onDidChangeVisibleTextEditors(_ => {
+        updateVisibleHeatmaps();
     }, null, context.subscriptions)
 }
 


### PR DESCRIPTION
A few tweaks (see individual commit messages), but mostly to enable the feature of showing the highlights in the overview ruler.

I'm not sure if it's possible to get the highlighting to show up on the minimap, but showing it on the ruler gets you close to the same usability.

Sort-of partially closes #1.