### PR TITLE
Configure cool color

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Heatmap adds the following commands to the command palette:
 |Property|Description|Type|Default value|
 |---|---|---|---|
 |`heatmap.heatLevels`|The number of different heat levels to visualise.|Integer|10|
-|`heatmap.heatColour`|The R,G,B of the brightest heat level.|String|`200,0,0`|
+|`heatmap.heatColour`|The colour of the "hottest" heat level (most recent changes), as a list of numbers R, G, B, or a hex colour code.|String|`200,0,0` or `#C80000`|
 |`heatmap.showInRuler`|Whether to show the heatmap in the overview ruler.|Boolean|true|
 
 ## Thanks

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Heatmap adds the following commands to the command palette:
 |---|---|---|---|
 |`heatmap.heatLevels`|The number of different heat levels to visualise.|Integer|10|
 |`heatmap.heatColour`|The colour of the "hottest" heat level (most recent changes), as a list of numbers R, G, B, or a hex colour code.|String|`200,0,0` or `#C80000`|
+|`heatmap.coolColour`|The colour of the "coolest" heat level (oldest changes), as a list of numbers R, G, B, or a hex colour code.|String|Same as heatColour, but with 100% alpha|
 |`heatmap.showInRuler`|Whether to show the heatmap in the overview ruler.|Boolean|true|
 
 ## Thanks

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Heatmap adds the following commands to the command palette:
 |---|---|---|---|
 |`heatmap.heatLevels`|The number of different heat levels to visualise.|Integer|10|
 |`heatmap.heatColour`|The R,G,B of the brightest heat level.|String|`200,0,0`|
+|`heatmap.showInRuler`|Whether to show the heatmap in the overview ruler.|Boolean|true|
 
 ## Thanks
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,18 @@
 {
   "name": "heatmap",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "heatmap",
-      "version": "0.0.1",
+      "version": "0.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^4.2.3"
+      },
       "devDependencies": {
+        "@types/color": "^3.0.6",
         "@types/mocha": "^10.0.2",
         "@types/node": "18.x",
         "@types/vscode": "^1.83.0",
@@ -218,6 +223,33 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/@types/color": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/color/-/color-3.0.6.tgz",
+      "integrity": "sha512-NMiNcZFRUAiUUCCf7zkAelY8eV3aKqfbzyFQlXpPIEeoNDbsEHGpb854V3gzTsGKYj830I5zPuOwU/TP5/cW6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/color-convert": "*"
+      }
+    },
+    "node_modules/@types/color-convert": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-2.0.3.tgz",
+      "integrity": "sha512-2Q6wzrNiuEvYxVQqhh7sXM2mhIhvZR/Paq4FdsQkOMgWsCIkKvSGj8Le1/XalulrmgOzPMqNa0ix+ePY4hTrfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/color-name": "*"
+      }
+    },
+    "node_modules/@types/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-hulKeREDdLFesGQjl96+4aoJSHY5b2GRjagzzcqCfIrWhe5vkCqIvrLbqzBaI1q94Vg8DNJZZqTR5ocdWmWclg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.14",
@@ -736,11 +768,23 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -751,8 +795,17 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -1391,6 +1444,12 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "license": "MIT"
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -2195,6 +2254,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
       }
     },
     "node_modules/slash": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,11 @@
           "type": "string",
           "default": "200,0,0",
           "description": "The heat colour to use as R,G,B between 0-255 for each."
+        },
+        "heatmap.showInRuler": {
+          "type": "boolean",
+          "default": true,
+          "description": "When the heatmap is switched on, also show it in the overview ruler."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,11 @@
           "default": "200,0,0",
           "description": "The heat colour to use as R,G,B between 0-255 for each, or hex colour code."
         },
+        "heatmap.coolColour": {
+          "type": "string",
+          "default": "",
+          "description": "The cool colour to use as R,G,B between 0-255 for each, or hex colour code."
+        },
         "heatmap.showInRuler": {
           "type": "boolean",
           "default": true,

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "heatmap.heatColour": {
           "type": "string",
           "default": "200,0,0",
-          "description": "The heat colour to use as R,G,B between 0-255 for each."
+          "description": "The heat colour to use as R,G,B between 0-255 for each, or hex colour code."
         },
         "heatmap.showInRuler": {
           "type": "boolean",
@@ -73,15 +73,19 @@
     "test": "node ./out/test/runTest.js"
   },
   "devDependencies": {
-    "@types/vscode": "^1.83.0",
+    "@types/color": "^3.0.6",
     "@types/mocha": "^10.0.2",
     "@types/node": "18.x",
+    "@types/vscode": "^1.83.0",
     "@typescript-eslint/eslint-plugin": "^6.7.3",
     "@typescript-eslint/parser": "^6.7.3",
+    "@vscode/test-electron": "^2.3.4",
     "eslint": "^8.50.0",
     "glob": "^10.3.3",
     "mocha": "^10.2.0",
-    "typescript": "^5.2.2",
-    "@vscode/test-electron": "^2.3.4"
+    "typescript": "^5.2.2"
+  },
+  "dependencies": {
+    "color": "^4.2.3"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -160,6 +160,7 @@ function buildDecorations(){
 	heatStyles.length = 0;
 	for (let i = 0; i < heatLevels; ++i) {
 		heatStyles.push(vscode.window.createTextEditorDecorationType({
+			rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed,
 			backgroundColor: 'rgba(' + heatColour + ', ' + (heatPerLevel * i) + ')',
 		}));
 	}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -179,6 +179,9 @@ function buildDecorations(){
 	const heatColor = colorFromString(config.get<string>('heatColour', ""), DEFAULT_HEAT_COLOUR);
 	const showInRuler = config.get<boolean>('showInRuler');
 
+	const defaultCoolColor = heatColor.alpha(0);
+	const coolColor = colorFromString(config.get<string>('coolColour', ""), defaultCoolColor);
+
 	if (heatLevels < 1) {
 		vscode.window.showErrorMessage('Heatmap: Invalid number of heat levels (must be >1).');
 		return;
@@ -194,7 +197,8 @@ function buildDecorations(){
 
 	heatStyles.length = 0;
 	for (let i = 0; i < heatLevels; ++i) {
-		const colorString = heatColor.alpha(heatPerLevel * i).hexa();
+		const colorString = coolColor.mix(heatColor, heatPerLevel * i).hexa();
+
 		heatStyles.push(vscode.window.createTextEditorDecorationType({
 			rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed,
 			backgroundColor: colorString,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -143,6 +143,7 @@ function buildDecorations(){
 	const config = vscode.workspace.getConfiguration('heatmap');
 	const heatLevels = config.get<number>('heatLevels') || DEFAULT_HEAT_LEVELS;
 	const heatColour = config.get<string>('heatColour') || DEFAULT_HEAT_COLOUR;
+	const showInRuler = config.get<boolean>('showInRuler');
 
 	if (heatLevels < 1) {
 		vscode.window.showErrorMessage('Heatmap: Invalid number of heat levels (must be >1).');
@@ -159,9 +160,11 @@ function buildDecorations(){
 
 	heatStyles.length = 0;
 	for (let i = 0; i < heatLevels; ++i) {
+		const colorString = 'rgba(' + heatColour + ', ' + (heatPerLevel * i) + ')';
 		heatStyles.push(vscode.window.createTextEditorDecorationType({
 			rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed,
-			backgroundColor: 'rgba(' + heatColour + ', ' + (heatPerLevel * i) + ')',
+			backgroundColor: colorString,
+			overviewRulerColor: showInRuler ? colorString : undefined,
 		}));
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,12 +50,13 @@ function getGitTimestampsForLines(document: vscode.TextDocument): undefined | nu
 	return timestamps;
 }
 
-function updateHeatmap(){
-	const editor = vscode.window.activeTextEditor;
-	if (!editor) {
-		return;
-	}
+function updateVisibleHeatmaps(){
+	vscode.window.visibleTextEditors.forEach(editor => {
+		updateHeatmapForEditor(editor);
+	});
+}
 
+function updateHeatmapForEditor(editor:vscode.TextEditor){
 	// clear whatever was already there
 	heatStyles.forEach(style => editor.setDecorations(style, []));
 
@@ -120,7 +121,7 @@ function setHeatmapEnabled(enable: boolean) {
 		enabledForFiles.delete(editor.document.uri);
 	}
 
-	updateHeatmap();
+	updateVisibleHeatmaps();
 }
 
 function toggleHeatmap(){
@@ -135,7 +136,7 @@ function toggleHeatmap(){
 		enabledForFiles.add(editor.document.uri);
 	}
 
-	updateHeatmap();
+	updateVisibleHeatmaps();
 }
 
 export function activate(context: vscode.ExtensionContext) {
@@ -164,8 +165,8 @@ export function activate(context: vscode.ExtensionContext) {
 
 	commands.forEach(cmd => context.subscriptions.push(cmd));
 
-	vscode.window.onDidChangeActiveTextEditor(_ => {
-        updateHeatmap();
+	vscode.window.onDidChangeVisibleTextEditors(_ => {
+        updateVisibleHeatmaps();
     }, null, context.subscriptions)
 }
 


### PR DESCRIPTION
Adds a configuration option for specifying the "cool" color to highlight the oldest changes with. The heat levels interpolate from the hot to cold color. The default cool color is equal to the hot color but with 100% alpha (i.e. no change from the way it looks currently).

This applies on top of PR #7, and closes #4.

Note: I added the `color` package to represent colors do the interpolation. I'm not sure if I've added it correctly to `package.json` and `package-lock.json` - I'm not very familiar with node/npm. Lots of other things changed in those files as well - I'm not sure if that's right.